### PR TITLE
Make Pointer conversion more liberal

### DIFF
--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -303,48 +303,51 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
 
       return false;
     }
-    else if(!is_subtype(arg_type, wp_type, &info, opt) && (!is_bare || (!void_star_param(wp_type, arg_type))))
+    else if(!is_allowed_pointer_conversion(arg_type, wp_type, opt, &info))
     {
-      errorframe_t frame = NULL;
-      ast_error_frame(&frame, arg, "argument not assignable to parameter");
-      ast_error_frame(&frame, arg, "argument type is %s",
-                      ast_print_type(arg_type));
-      ast_error_frame(&frame, param, "parameter type requires %s",
-                      ast_print_type(wp_type));
+      if(!is_subtype(arg_type, wp_type, &info, opt) && (!is_bare || (!void_star_param(wp_type, arg_type))))
+      {
+        errorframe_t frame = NULL;
+        ast_error_frame(&frame, arg, "argument not assignable to parameter");
+        ast_error_frame(&frame, arg, "argument type is %s",
+          ast_print_type(arg_type));
+        ast_error_frame(&frame, param, "parameter type requires %s",
+          ast_print_type(wp_type));
 
-      if (ast_childcount(arg) > 1)
-        ast_error_frame(&frame, arg,
-          "note that arguments must be separated by a comma");
+        if(ast_childcount(arg) > 1)
+          ast_error_frame(&frame, arg,
+            "note that arguments must be separated by a comma");
 
-      if(ast_checkflag(ast_type(arg), AST_FLAG_INCOMPLETE))
-        ast_error_frame(&frame, arg,
-          "this might be possible if all fields were already defined");
+        if(ast_checkflag(ast_type(arg), AST_FLAG_INCOMPLETE))
+          ast_error_frame(&frame, arg,
+            "this might be possible if all fields were already defined");
 
-      errorframe_append(&frame, &info);
-      errorframe_report(&frame, opt->check.errors);
-      ast_free_unattached(wp_type);
-      return false;
-    }
-    else if((ast_id(wp_type) == TK_UNIONTYPE || ast_id(wp_type) == TK_ISECTTYPE) &&
-            contains_struct(wp_type))
-    {
-      errorframe_t frame = NULL;
-      ast_error_frame(&frame, wp_type,
-        "Cannot assign to a parameter with a union or isect type that contains a struct");
+        errorframe_append(&frame, &info);
+        errorframe_report(&frame, opt->check.errors);
+        ast_free_unattached(wp_type);
+        return false;
+      }
+      else if((ast_id(wp_type) == TK_UNIONTYPE || ast_id(wp_type) == TK_ISECTTYPE) &&
+        contains_struct(wp_type))
+      {
+        errorframe_t frame = NULL;
+        ast_error_frame(&frame, wp_type,
+          "Cannot assign to a parameter with a union or isect type that contains a struct");
 
-      errorframe_append(&frame, &info);
-      errorframe_report(&frame, opt->check.errors);
-      return false;
-    }
-    else if(contains_entity_type(wp_type))
-    {
-      errorframe_t frame = NULL;
-      ast_error_frame(&frame, wp_type,
-        "Cannot assign to a parameter type that contains an entity type");
+        errorframe_append(&frame, &info);
+        errorframe_report(&frame, opt->check.errors);
+        return false;
+      }
+      else if(contains_entity_type(wp_type))
+      {
+        errorframe_t frame = NULL;
+        ast_error_frame(&frame, wp_type,
+          "Cannot assign to a parameter type that contains an entity type");
 
-      errorframe_append(&frame, &info);
-      errorframe_report(&frame, opt->check.errors);
-      return false;
+        errorframe_append(&frame, &info);
+        errorframe_report(&frame, opt->check.errors);
+        return false;
+      }
     }
 
     ast_free_unattached(wp_type);

--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -116,19 +116,42 @@ static bool declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)
     ast_t* a_type = alias(arg_type);
     errorframe_t info = NULL;
 
-    if(!void_star_param(p_type, a_type) &&
-      !is_subtype(a_type, p_type, &info, opt))
+    if(!is_allowed_pointer_conversion(a_type, p_type, opt, &info))
     {
       errorframe_t frame = NULL;
-      ast_error_frame(&frame, arg, "argument not a assignable to parameter");
-      ast_error_frame(&frame, arg, "argument type is %s",
-                      ast_print_type(a_type));
-      ast_error_frame(&frame, param, "parameter type requires %s",
-                      ast_print_type(p_type));
-      errorframe_append(&frame, &info);
-      errorframe_report(&frame, opt->check.errors);
-      ast_free_unattached(a_type);
-      return false;
+
+      if(!void_star_param(p_type, a_type) &&
+         !is_subtype(a_type, p_type, &info, opt))
+      {
+        ast_error_frame(&frame, arg, "argument not a assignable to parameter");
+        ast_error_frame(&frame, arg, "argument type is %s",
+          ast_print_type(a_type));
+        ast_error_frame(&frame, param, "parameter type requires %s",
+          ast_print_type(p_type));
+        errorframe_append(&frame, &info);
+        errorframe_report(&frame, opt->check.errors);
+        ast_free_unattached(a_type);
+        return false;
+      }
+      else if((ast_id(a_type) == TK_UNIONTYPE || ast_id(a_type) == TK_ISECTTYPE) &&
+        contains_struct(a_type))
+      {
+        ast_error_frame(&info, a_type,
+          "Cannot assign to a union or isect type that contains a struct");
+
+        errorframe_append(&frame, &info);
+        errorframe_report(&frame, opt->check.errors);
+        return false;
+      }
+      else if(contains_entity_type(a_type))
+      {
+        ast_error_frame(&info, a_type,
+          "Cannot assign to a type that contains an entity type");
+
+        errorframe_append(&frame, &info);
+        errorframe_report(&frame, opt->check.errors);
+        return false;
+      }
     }
 
     ast_free_unattached(a_type);

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -623,37 +623,40 @@ bool expr_assign(pass_opt_t* opt, ast_t** astp)
     errorframe_report(&frame, opt->check.errors);
     return false;
   }
-  else if(!is_subtype(r_type, wl_type, &info, opt))
+  else if(!is_allowed_pointer_conversion(wl_type, r_type, opt, &info))
   {
-    ast_error_frame(&frame, ast, "right side must be a subtype of left side");
+    if(!is_subtype(r_type, wl_type, &info, opt))
+    {
+      ast_error_frame(&frame, ast, "right side must be a subtype of left side");
 
-    if(ast_checkflag(ast_type(right), AST_FLAG_INCOMPLETE))
-      ast_error_frame(&frame, right,
-        "this might be possible if all fields were already defined");
+      if(ast_checkflag(ast_type(right), AST_FLAG_INCOMPLETE))
+        ast_error_frame(&frame, right,
+          "this might be possible if all fields were already defined");
 
-    errorframe_append(&frame, &info);
-    errorframe_report(&frame, opt->check.errors);
-    ast_free_unattached(wl_type);
-    return false;
-  }
-  else if((ast_id(wl_type) == TK_UNIONTYPE || ast_id(wl_type) == TK_ISECTTYPE) &&
-          contains_struct(wl_type))
-  {
-    ast_error_frame(&frame, wl_type,
-      "Cannot assign to a union or isect type that contains a struct");
+      errorframe_append(&frame, &info);
+      errorframe_report(&frame, opt->check.errors);
+      ast_free_unattached(wl_type);
+      return false;
+    }
+    else if((ast_id(wl_type) == TK_UNIONTYPE || ast_id(wl_type) == TK_ISECTTYPE) &&
+      contains_struct(wl_type))
+    {
+      ast_error_frame(&frame, wl_type,
+        "Cannot assign to a union or isect type that contains a struct");
 
-    errorframe_append(&frame, &info);
-    errorframe_report(&frame, opt->check.errors);
-    return false;
-  }
-  else if(contains_entity_type(wl_type))
-  {
-    ast_error_frame(&frame, wl_type,
-      "Cannot assign to a type that contains an entity type");
+      errorframe_append(&frame, &info);
+      errorframe_report(&frame, opt->check.errors);
+      return false;
+    }
+    else if(contains_entity_type(wl_type))
+    {
+      ast_error_frame(&frame, wl_type,
+        "Cannot assign to a type that contains an entity type");
 
-    errorframe_append(&frame, &info);
-    errorframe_report(&frame, opt->check.errors);
-    return false;
+      errorframe_append(&frame, &info);
+      errorframe_report(&frame, opt->check.errors);
+      return false;
+    }
   }
 
   if((ast_id(left) == TK_TUPLE) && (ast_id(r_type) != TK_TUPLETYPE))

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -1073,27 +1073,6 @@ static bool is_nominal_sub_entity(ast_t* sub, ast_t* super,
   ast_t* super_def = (ast_t*)ast_data(super);
   bool ret = true;
 
-  if(is_bare(sub) && is_pointer(super))
-  {
-    ast_t* super_typeargs = ast_childidx(super, 2);
-    ast_t* super_typearg = ast_child(super_typeargs);
-
-    // A bare type is a subtype of Pointer[None].
-    if(is_none(super_typearg))
-      return true;
-  }
-  // Implicit struct/class to pointer conversion
-  else if(is_pointer(super) &&
-          (ast_id(sub) == TK_NOMINAL && (ast_id(sub_def) == TK_STRUCT || ast_id(sub_def) == TK_CLASS)))
-  {
-    ast_t* pointer_elem_type = ast_child(ast_childidx(super, 2));
-
-    if(is_none(pointer_elem_type) || is_eqtype(pointer_elem_type, sub, errorf, opt))
-    {
-      return true;
-    }
-  }
-
   if(sub_def != super_def)
   {
     if(errorf != NULL)
@@ -2849,6 +2828,73 @@ bool is_pointer_referenced_object(ast_t* type)
 
     default:
       break;
+  }
+
+  return false;
+}
+
+
+bool is_allowed_pointer_conversion(ast_t* l_type, ast_t* r_type, pass_opt_t* opt, errorframe_t* frame)
+{
+  if(is_bare(l_type))
+  {
+    // Implicit pointer to lambda conversion
+    if(is_pointer(r_type))
+    {
+      ast_t* pointer_typeargs = ast_childidx(r_type, 2);
+      ast_t* pointer_typearg = ast_child(pointer_typeargs);
+
+      if(is_none(pointer_typearg) || is_eqtype(pointer_typearg, l_type, frame, opt))
+      {
+        return true;
+      }
+    }
+  }
+  else if(is_pointer(l_type))
+  {
+    // Implicit lambda to pointer conversion
+    if(is_bare(r_type))
+    {
+      ast_t* pointer_typeargs = ast_childidx(l_type, 2);
+      ast_t* pointer_typearg = ast_child(pointer_typeargs);
+
+      if(is_none(pointer_typearg) || is_eqtype(pointer_typearg, r_type, frame, opt))
+      {
+        return true;
+      }
+    }
+    // Implicit struct/class/actor to pointer conversion
+
+    ast_t* r_def = (ast_t*)ast_data(r_type);
+
+    if(ast_id(r_type) == TK_NOMINAL &&
+       (ast_id(r_def) == TK_STRUCT || ast_id(r_def) == TK_CLASS || ast_id(r_def) == TK_ACTOR))
+    {
+      ast_t* pointer_elem_type = ast_child(ast_childidx(l_type, 2));
+
+      if(is_none(pointer_elem_type) || is_eqtype(pointer_elem_type, r_type, frame, opt))
+      {
+        return true;
+      }
+    }
+  }
+
+  // Implicit pointer to struct/class/actor conversion
+
+  ast_t* l_def = (ast_t*)ast_data(l_type);
+
+  if(ast_id(l_type) == TK_NOMINAL &&
+    (ast_id(l_def) == TK_STRUCT || ast_id(l_def) == TK_CLASS || ast_id(l_def) == TK_ACTOR))
+  {
+    if(is_pointer(r_type))
+    {
+      ast_t* pointer_elem_type = ast_child(ast_childidx(r_type, 2));
+
+      if(is_none(pointer_elem_type) || is_eqtype(pointer_elem_type, l_type, frame, opt))
+      {
+        return true;
+      }
+    }
   }
 
   return false;

--- a/src/libponyc/type/subtype.h
+++ b/src/libponyc/type/subtype.h
@@ -77,6 +77,8 @@ ast_t* remove_entity_types(ast_t* type);
 
 bool is_pointer_referenced_object(ast_t* type);
 
+bool is_allowed_pointer_conversion(ast_t* l_type, ast_t* r_type, pass_opt_t* opt, errorframe_t* frame);
+
 PONY_EXTERN_C_END
 
 #endif

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -1252,17 +1252,3 @@ TEST_F(SubTypeTest, AllowedPointerConversion)
 
   TEST_COMPILE(src);
 }
-
-TEST_F(SubTypeTest, PointerFromNoneConversionFail)
-{
-  const char* src =
-    "struct S\n"
-
-    "primitive P\n"
-    "  fun apply() =>\n"
-    "    var s = S\n"
-    "    var ps: Pointer[None] = s\n"
-    "    var ps2: Pointer[S] = ps\n";
-
-  TEST_ERRORS_1(src, "right side must be a subtype of left side");
-}


### PR DESCRIPTION
Pointers can now be assigned between reference types and Pointer[None] back and forth.

let s: Struct = Pointer[None]
let p: Pointer[None] = s

Also bare lambdas can be converted from/to Pointer[None].

let l: @{(USize): USize} = Pointer[None]
let p: Pointer[None] = l

Also allowed when the type argument of Pointer matches the conversion type.

let s: Struct = Pointer[Struct]
let p: Pointer[Struct] = s

Removed that a bare lambda is a subtype of Pointer[None]. Instead this is handled by allowing implicit assignment/parameter passing. conversion.