### PR TITLE
Remove unnecessary ast_setdata

### DIFF
--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -596,7 +596,6 @@ bool refer_reference(pass_opt_t* opt, ast_t** astp)
     case TK_VALUEFORMALPARAM:
     {
       ast_setid(ast, TK_VALUEFORMALPARAMREF);
-      ast_setdata(ast, def);
       return true;
     }
 


### PR DESCRIPTION
Removed unnecessary ast_setdata for TK_VALUEFORMALPARAMREF in refer_reference in the refer pass.