### PR TITLE
Dispose directory in full-program-runner

### DIFF
--- a/test/full-program-runner/_test_definitions.pony
+++ b/test/full-program-runner/_test_definitions.pony
@@ -134,9 +134,14 @@ class _TestDefinitions
       end
     end
 
+    var ret: (_TestDefinition | None) = None
     if has_pony_sources then
-      _TestDefinition(child, dir.path.path, expected_exit_code)
+      ret = _TestDefinition(child, dir.path.path, expected_exit_code)
     end
+
+    dir.dispose()
+
+    ret
 
   fun _get_expected_exit_code(fp: FilePath): I32 ? =>
     match OpenFile(fp)


### PR DESCRIPTION
In the method _TestDefinition._get_definition a Directory class is created which opens a directory and this is not disposed of at the end of this method but when the GC finally runs.

Macos 26.4.1 update doesn't like that programs opens too many directories at the same time and seems to have an upper limit of 255.

Fixed _TestDefinition._get_definition so that Directory is disposed at the end of the method and frees the direcory handle.