### PR TITLE
Remove refering captures for bare lambdas

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -535,8 +535,8 @@ switch ($Command.ToLower())
             $env:PONYPATH = "$srcDir\packages"
 
             $numTestSuitesRun += 1;
-            Write-Output "$outDir\ponyc.exe --path $srcDir\tools\lib\ponylang\json-ng --path $srcDir\tools\lib\ponylang\pony_compiler -b pony-lint-tests -o $outDir $srcDir\tools\pony-lint\test"
-            & $outDir\ponyc.exe --path $srcDir\tools\lib\ponylang\json-ng --path $srcDir\tools\lib\ponylang\pony_compiler -b pony-lint-tests -o $outDir $srcDir\tools\pony-lint\test
+            Write-Output "$outDir\ponyc.exe --path $srcDir\tools\lib\ponylang\pony_compiler -b pony-lint-tests -o $outDir $srcDir\tools\pony-lint\test"
+            & $outDir\ponyc.exe --path $srcDir\tools\lib\ponylang\pony_compiler -b pony-lint-tests -o $outDir $srcDir\tools\pony-lint\test
             if ($LastExitCode -eq 0)
             {
                 try

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -1986,7 +1986,6 @@ ast_result_t pass_refer(ast_t** astp, pass_opt_t* options)
     case TK_COMPILE_ERROR:
                        r = refer_compile_error(options, ast); break;
     case TK_LAMBDA:
-    case TK_BARELAMBDA:
                        r = refer_lambda(options, ast); break;
     default: {}
   }


### PR DESCRIPTION
In refer.c, it tries to refer captures for bare lambdas leading to possible usage of outside variables when it is impossible for bare lambdas. Bare lambdas are just function pointers and have no context.

Removed unused -path in make.ps1