### PR TITLE
Change partial error return value to use undef

### DIFF
--- a/src/libponyc/codegen/gentryreturn.cc
+++ b/src/libponyc/codegen/gentryreturn.cc
@@ -255,7 +255,7 @@ extern "C" LLVMValueRef wrap_try_return_error(compile_t* c, TryReturnInfo* try_r
 
       LLVMValueRef tuple = LLVMGetUndef(try_return_info->wrapped_type);
       LLVMTypeRef mem_type = ((compile_type_t*)try_return_info->unwrapped_type->c_type)->mem_type;
-      tuple = LLVMBuildInsertValue(c->builder, tuple, LLVMConstNull(mem_type), 0, "");
+      tuple = LLVMBuildInsertValue(c->builder, tuple, LLVMGetUndef(mem_type), 0, "");
       ret = LLVMBuildInsertValue(c->builder, tuple, LLVMConstInt(bool_c_t->mem_type, 0, false), 1, "");
       break;
     }


### PR DESCRIPTION
Changed the error return value when (T, Bool) is used that the value T is given a value of undef instead of zero initialized. This might reduce the number of instructions needed for the error return path.