### PR TITLE
Add naked, noinline and alwaysinline annotations

### DIFF
--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -347,7 +347,7 @@ static void make_prototype(compile_t* c, reach_type_t* t,
     // Generate the function prototype.
     c_m->func = codegen_addfun(c, m->full_name, c_m->func_type, true);
     genfun_param_attrs(c, t, m, c_m->func);
-    genfun_function_attrs(c, t, m, c_m->func);
+    genfun_function_attrs(c, m, c_m->func);
     make_function_debug(c, t, m, c_m->func);
   } else {
     size_t count = LLVMCountParamTypes(c_m->func_type);
@@ -1188,8 +1188,7 @@ void genfun_param_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
   }
 }
 
-void genfun_function_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
-  LLVMValueRef fun)
+void genfun_function_attrs(compile_t* c, reach_method_t* m, LLVMValueRef fun)
 {
   bool naked = ast_has_annotation(m->fun->ast, "naked");
 

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -347,6 +347,7 @@ static void make_prototype(compile_t* c, reach_type_t* t,
     // Generate the function prototype.
     c_m->func = codegen_addfun(c, m->full_name, c_m->func_type, true);
     genfun_param_attrs(c, t, m, c_m->func);
+    genfun_function_attrs(c, t, m, c_m->func);
     make_function_debug(c, t, m, c_m->func);
   } else {
     size_t count = LLVMCountParamTypes(c_m->func_type);
@@ -572,17 +573,34 @@ static bool genfun_fun(compile_t* c, reach_type_t* t, reach_method_t* m)
 
   codegen_startfun(c, c_m->func, c_m->di_file, c_m->di_method, m->fun, m,
     ast_id(cap) == TK_AT);
-  name_params(c, t, m, c_m->func);
 
   bool finaliser = c_m->func == c_t->final_fn;
+  bool naked = ast_has_annotation(m->fun->ast, "naked");
 
-  if(finaliser)
-    call_embed_finalisers(c, t, body, gen_this(c, NULL));
+  if(!naked)
+  {
+    name_params(c, t, m, c_m->func);
+
+    if(finaliser)
+      call_embed_finalisers(c, t, body, gen_this(c, NULL));
+  }
 
   LLVMValueRef value = gen_expr(c, body);
 
   if(value == NULL)
     return false;
+
+  // Naked function, nothing more to do just get out
+  if(naked)
+  {
+    codegen_debugloc(c, ast_childlast(body));
+    // Naked functions do not use a LLVM IR ret instruction but just unreachable
+    // The ret instruction must be inserted manually with inline assembler
+    LLVMBuildUnreachable(c->builder);
+    codegen_debugloc(c, NULL);
+    codegen_finishfun(c);
+    return true;
+  }
 
   bool return_by_value = m->return_by_value;
   bool return_value_lowered = c_m->return_value_lowered;
@@ -1167,6 +1185,36 @@ void genfun_param_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
 
     param = LLVMGetNextParam(param);
     ++i;
+  }
+}
+
+void genfun_function_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
+  LLVMValueRef fun)
+{
+  bool naked = ast_has_annotation(m->fun->ast, "naked");
+
+  if(naked)
+  {
+    unsigned attr_id = LLVMGetEnumAttributeKindForName("naked",
+      sizeof("naked") - 1);
+    LLVMAttributeRef attr_ref = LLVMCreateEnumAttribute(c->context, attr_id, 0);
+    LLVMAddAttributeAtIndex(fun, LLVMAttributeFunctionIndex, attr_ref);
+  }
+
+  if(naked || ast_has_annotation(m->fun->ast, "noinline"))
+  {
+    unsigned attr_id = LLVMGetEnumAttributeKindForName("noinline",
+      sizeof("noinline") - 1);
+    LLVMAttributeRef attr_ref = LLVMCreateEnumAttribute(c->context, attr_id, 0);
+    LLVMAddAttributeAtIndex(fun, LLVMAttributeFunctionIndex, attr_ref);
+  }
+
+  if(ast_has_annotation(m->fun->ast, "alwaysinline"))
+  {
+    unsigned attr_id = LLVMGetEnumAttributeKindForName("alwaysinline",
+      sizeof("alwaysinline") - 1);
+    LLVMAttributeRef attr_ref = LLVMCreateEnumAttribute(c->context, attr_id, 0);
+    LLVMAddAttributeAtIndex(fun, LLVMAttributeFunctionIndex, attr_ref);
   }
 }
 

--- a/src/libponyc/codegen/genfun.h
+++ b/src/libponyc/codegen/genfun.h
@@ -25,8 +25,7 @@ typedef struct compile_method_t
 void genfun_param_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
   LLVMValueRef fun);
 
-void genfun_function_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
-  LLVMValueRef fun);
+void genfun_function_attrs(compile_t* c, reach_method_t* m, LLVMValueRef fun);
 
 void genfun_allocate_compile_methods(compile_t* c, reach_type_t* t);
 

--- a/src/libponyc/codegen/genfun.h
+++ b/src/libponyc/codegen/genfun.h
@@ -25,6 +25,9 @@ typedef struct compile_method_t
 void genfun_param_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
   LLVMValueRef fun);
 
+void genfun_function_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
+  LLVMValueRef fun);
+
 void genfun_allocate_compile_methods(compile_t* c, reach_type_t* t);
 
 bool genfun_method_sigs(compile_t* c, reach_type_t* t);

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -1612,7 +1612,8 @@ static bool check_annotation_location(pass_opt_t* opt, ast_t* ast,
     {
       pony_assert(ast_id(ast_parent(parent2)) == TK_PARAMS);
       ast_t* parent4 = ast_parent(ast_parent(parent2));
-      if(ast_id(parent4) == TK_FFIDECL || ast_id(parent4) == TK_BARELAMBDA)
+      if(ast_id(parent4) == TK_FFIDECL || ast_id(parent4) == TK_BARELAMBDA ||
+         ast_id(parent4) == TK_FUN && ast_id(ast_child(parent4)) == TK_AT)
       {
         return true;
       }
@@ -1634,7 +1635,8 @@ static bool check_annotation_location(pass_opt_t* opt, ast_t* ast,
         return true;
       }
     }
-    else if(ast_id(parent2) == TK_BARELAMBDATYPE || ast_id(parent2) == TK_BARELAMBDA)
+    else if(ast_id(parent2) == TK_BARELAMBDATYPE || ast_id(parent2) == TK_BARELAMBDA ||
+            ast_id(parent2) == TK_FUN && ast_id(ast_child(parent2)) == TK_AT)
     {
       // The return value of a bare lambda call or type declaration
       return true;
@@ -1642,7 +1644,7 @@ static bool check_annotation_location(pass_opt_t* opt, ast_t* ast,
 
     ast_error(opt->check.errors, loc,
       "a '" PONY_BYVAL_ANNOTATION "' annotation can only be used on parameter types in FFI "
-      "and bare lambda declarations");
+      "functions, bare lambda and bare functions declarations");
     return false;
   }
   else if(strcmp(str, "property") == 0)
@@ -1702,6 +1704,18 @@ static bool check_annotation_location(pass_opt_t* opt, ast_t* ast,
     {
       ast_error(opt->check.errors, loc,
         "a property method cannot have more than one parameters");
+      return false;
+    }
+  }
+  else if(strcmp(str, "naked") == 0 || strcmp(str, "noinline") == 0 ||
+          strcmp(str, "alwaysinline") == 0)
+  {
+    ast_t* def = ast_parent(ast);
+    token_id def_id = ast_id(def);
+    if(def_id != TK_FUN && def_id != TK_LAMBDA && def_id != TK_BARELAMBDA)
+    {
+      ast_error(opt->check.errors, loc,
+        "a '%s' annotation can only be used on functions and lambdas", str);
       return false;
     }
   }

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -1613,7 +1613,7 @@ static bool check_annotation_location(pass_opt_t* opt, ast_t* ast,
       pony_assert(ast_id(ast_parent(parent2)) == TK_PARAMS);
       ast_t* parent4 = ast_parent(ast_parent(parent2));
       if(ast_id(parent4) == TK_FFIDECL || ast_id(parent4) == TK_BARELAMBDA ||
-         ast_id(parent4) == TK_FUN && ast_id(ast_child(parent4)) == TK_AT)
+         (ast_id(parent4) == TK_FUN && ast_id(ast_child(parent4)) == TK_AT))
       {
         return true;
       }
@@ -1636,9 +1636,9 @@ static bool check_annotation_location(pass_opt_t* opt, ast_t* ast,
       }
     }
     else if(ast_id(parent2) == TK_BARELAMBDATYPE || ast_id(parent2) == TK_BARELAMBDA ||
-            ast_id(parent2) == TK_FUN && ast_id(ast_child(parent2)) == TK_AT)
+            (ast_id(parent2) == TK_FUN && ast_id(ast_child(parent2)) == TK_AT))
     {
-      // The return value of a bare lambda call or type declaration
+      // The return value of a bare lambda call or type declaration or bare method
       return true;
     }
 

--- a/src/libponyc/verify/fun.c
+++ b/src/libponyc/verify/fun.c
@@ -604,5 +604,23 @@ bool verify_fun(pass_opt_t* opt, ast_t* ast)
     }
   }
 
+  bool naked = ast_has_annotation(ast, "naked");
+  bool noinline = ast_has_annotation(ast, "noinline");
+  bool alwaysinline = ast_has_annotation(ast, "alwaysinline");
+
+  if(naked && alwaysinline)
+  {
+    ast_error(opt->check.errors, ast, "naked functions are implicitly "
+     "noinline cannot be combined with the 'alwaysinline' annotation");
+    return false;
+  }
+
+  if(noinline && alwaysinline)
+  {
+    ast_error(opt->check.errors, ast, "'noinline' and 'alwaysinline' annotations "
+      "cannot be used at the same time");
+    return false;
+  }
+
   return true;
 }

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -1924,3 +1924,23 @@ TEST_F(BadPonyTest, MatchLiteralCaseWithTypecheckErrorElse)
 
   TEST_ERRORS_1(src, "argument not assignable to parameter");
 }
+
+TEST_F(BadPonyTest, NakedAndAlwaysInlineNotAllowed)
+{
+  const char* src =
+    "primitive Foo\n"
+    "  fun \\naked, alwaysinline\\ bar(x: U32): U32 => x\n";
+
+  TEST_ERRORS_1(src, "naked functions are implicitly "
+    "noinline cannot be combined with the 'alwaysinline' annotation");
+}
+
+TEST_F(BadPonyTest, NoInlineAndAlwaysInlineNotAllowed)
+{
+  const char* src =
+    "primitive Foo\n"
+    "  fun \\noinline, alwaysinline\\ bar(x: U32): U32 => x\n";
+
+  TEST_ERRORS_1(src, "'noinline' and 'alwaysinline' annotations "
+    "cannot be used at the same time");
+}


### PR DESCRIPTION
Added naked annotation in order to support functions with no stack prologue and epilogue code.

Added noinline in order prevent function inling.
Added alwaysinline in order to force inlining.

Removed that bare methods was mistakenly omitted as candidates for \byval\ pass by value parameters. Added bare methods as well to be allowed to use \byval\ just like bare lamdas and FFI functions.