### PR TITLE
Add TK_VALUEFORMALPARAMREF in exact_type

### DIFF
--- a/packages/builtin/c_fixed_sized_array.pony
+++ b/packages/builtin/c_fixed_sized_array.pony
@@ -211,7 +211,7 @@ fun pairs(): CFixedSizedArrayPairs[A, _size, this->CFixedSizedArray[A, _size]]^ 
   CFixedSizedArrayPairs[A, _size, this->CFixedSizedArray[A, _size]](this)
 
 
-class CFixedSizedArrayKeys[A, _size: USize, \allowbaretypes\ B: CFixedSizedArray[A, _size] #read] is Iterator[USize]
+class CFixedSizedArrayKeys[\allowbaretypes\ A, _size: USize, \allowbaretypes\ B: CFixedSizedArray[A, _size] #read] is Iterator[USize]
   let _array: B
   var _i: USize
 
@@ -230,7 +230,7 @@ class CFixedSizedArrayKeys[A, _size: USize, \allowbaretypes\ B: CFixedSizedArray
     end
 
 
-class CFixedSizedArrayValues[A, _size: USize, \allowbaretypes\ B: CFixedSizedArray[A, _size] #read] is Iterator[B->A]
+class CFixedSizedArrayValues[\allowbaretypes\ A, _size: USize, \allowbaretypes\ B: CFixedSizedArray[A, _size] #read] is Iterator[B->A]
   let _array: B
   var _i: USize
 
@@ -245,7 +245,7 @@ class CFixedSizedArrayValues[A, _size: USize, \allowbaretypes\ B: CFixedSizedArr
     _array(_i = _i + 1)?
 
 
-class CFixedSizedArrayPairs[A, _size: USize, \allowbaretypes\ B: CFixedSizedArray[A, _size] #read] is Iterator[(USize, B->A)]
+class CFixedSizedArrayPairs[\allowbaretypes\ A, _size: USize, \allowbaretypes\ B: CFixedSizedArray[A, _size] #read] is Iterator[(USize, B->A)]
   let _array: B
   var _i: USize
 

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -52,6 +52,39 @@ static void struct_cant_be_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
     ast_print_type(sub), ast_print_type(super), entity);
 }
 
+static ast_t* get_valueformalarg_def(ast_t* ast)
+{
+  if(ast_id(ast) != TK_VALUEFORMALPARAMREF && ast_id(ast) != TK_VALUEFORMALARG)
+  {
+    return NULL;
+  }
+
+  ast_t* parent = ast_parent(ast);
+  ast_t* parent2 = ast_parent(parent);
+
+  ast_t* def = NULL;
+
+  switch(ast_id(parent2))
+  {
+    case TK_NOMINAL:
+    case TK_TYPEREF:
+      def = (ast_t*)ast_data(parent2);
+      break;
+
+    default:
+      pony_assert(false);
+      break;
+  }
+
+  size_t index = ast_index(ast);
+
+  ast_t* type_params = ast_childidx(def, 1);
+
+  ast_t* typeparam = ast_childidx(type_params, index);
+
+  return typeparam;
+}
+
 // Structural AST equality on type expressions, used by check_assume to
 // recognize when the current (sub, super) pair has already been pushed
 // onto the assume stack. This must NOT call back into the subtype
@@ -114,6 +147,29 @@ static bool exact_type(ast_t* a, ast_t* b)
       // Children of TK_TYPEPARAMREF: id, cap, ephemeral.
       return (ast_id(ast_childidx(a, 1)) == ast_id(ast_childidx(b, 1)))
         && (ast_id(ast_childidx(a, 2)) == ast_id(ast_childidx(b, 2)));
+    }
+
+    case TK_VALUEFORMALARG:
+      return false;
+
+    case TK_VALUEFORMALPARAMREF:
+    {
+      ast_t* a_data = (ast_t*)ast_data(a);
+      ast_t* b_data = (ast_t*)ast_data(b);
+
+      if(a_data != b_data)
+      {
+        return false;
+      }
+
+      ast_t* a_def = get_valueformalarg_def(a);
+      ast_t* b_def = get_valueformalarg_def(b);
+      if(a_def == NULL || b_def == NULL)
+      {
+        return false;
+      }
+
+      return a_def == b_def;
     }
 
     case TK_TYPEALIASREF:
@@ -375,36 +431,6 @@ bool is_literal_equal(ast_t* a, ast_t* b, pass_opt_t* opt, bool allow_eq_list)
   return false;
 }
 
-static ast_t* get_valueformalarg_type(ast_t* ast)
-{
-  ast_t* parent = ast_parent(ast);
-  ast_t* parent2 = ast_parent(parent);
-
-  ast_t* def = NULL;
-
-  switch(ast_id(parent2))
-  {
-    case TK_NOMINAL:
-    case TK_TYPEREF:
-      def = (ast_t*)ast_data(parent2);
-      break;
-
-    default:
-      pony_assert(false);
-      break;
-  }
-
-  size_t index = ast_index(ast);
-
-  ast_t* type_params = ast_childidx(def, 1);
-
-  ast_t* typeparam = ast_childidx(type_params, index);
-
-  ast_t* arg_type = ast_childidx(typeparam, 1);
-
-  return arg_type;
-}
-
 static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errorf,
   pass_opt_t* opt)
 {
@@ -431,7 +457,10 @@ static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errorf,
       if (!is_literal_equal(lit_a, lit_b, opt, true))
         ret = false;
 
-      if (!is_eqtype(get_valueformalarg_type(a_arg), get_valueformalarg_type(b_arg), errorf, opt))
+      ast_t* typeparam_a = get_valueformalarg_def(a_arg);
+      ast_t* typeparam_b = get_valueformalarg_def(b_arg);
+
+      if (!is_eqtype(ast_childidx(typeparam_a, 1), ast_childidx(typeparam_b, 1), errorf, opt))
         ret = false;
     }
     else

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -1533,3 +1533,75 @@ TEST_F(SubTypeTest, IsExactTypeWalksIntersectionTypes)
   ASSERT_TRUE(is_exact_type(t_a, t_b));
   ASSERT_FALSE(is_exact_type(t_a, t_c));
 }
+
+TEST_F(SubTypeTest, IsExactTypeValueTypeParamDistinguishesTypeParamScopes)
+{
+  const char* src =
+    "class _W[n: USize]\n"
+
+    "class _C1[u: USize]\n"
+    "  fun ref method_c1(p_in_c1: _W[u]) => None\n"
+
+    "class _C2[u: USize]\n"
+    "  fun ref method_c2(p_in_c2: _W[u]) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+
+  ast_t* t_c1 = type_of("p_in_c1");
+  ast_t* t_c2 = type_of("p_in_c2");
+  ASSERT_NE((void*)NULL, t_c1);
+  ASSERT_NE((void*)NULL, t_c2);
+
+  ASSERT_STREQ(ast_print_type(t_c1), ast_print_type(t_c2));
+
+  ASSERT_FALSE(is_exact_type(t_c1, t_c2));
+}
+
+TEST_F(SubTypeTest, IsExactTypeValueTypeParamDistinguishesMethodTypeParamScopes)
+{
+  const char* src =
+    "class _W[n: USize]\n"
+
+    "class _C\n"
+    "  fun ref method_a[u: USize](p_in_a: _W[u]) => None\n"
+    "  fun ref method_b[u: USize](p_in_b: _W[u]) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+
+  ast_t* t_a = type_of("p_in_a");
+  ast_t* t_b = type_of("p_in_b");
+  ASSERT_NE((void*)NULL, t_a);
+  ASSERT_NE((void*)NULL, t_b);
+
+  ASSERT_STREQ(ast_print_type(t_a), ast_print_type(t_b));
+
+  ASSERT_FALSE(is_exact_type(t_a, t_b));
+}
+
+TEST_F(SubTypeTest, IsExactTypeValueTypeParamMatchesSameTypeParamRef)
+{
+  const char* src =
+    "class _W[u: USize]\n"
+
+    "class _C[v: USize]\n"
+    "  fun ref method_a(p_a: _W[v]) => None\n"
+    "  fun ref method_b(p_b: _W[v]) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+
+  ast_t* t_a = type_of("p_a");
+  ast_t* t_b = type_of("p_b");
+  ASSERT_NE((void*)NULL, t_a);
+  ASSERT_NE((void*)NULL, t_b);
+
+  ASSERT_TRUE(is_exact_type(t_a, t_b));
+}

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -67,6 +67,7 @@ static const char* const _builtin =
   "  new create(a: USize = 0) => a\n"
   "  fun u64(): U64 => compile_intrinsic\n"
   "  fun op_xor(a: USize): USize => this xor a\n"
+  "  fun mul(a: USize): USize => this * a\n"
   "primitive ISize is Real[ISize]"
   "  new create(a: ISize = 0) => a\n"
   "  fun neg(): ISize => -this\n"
@@ -119,7 +120,20 @@ static const char* const _builtin =
   "  fun apply[A](obj: A) => compile_intrinsic\n"
   "struct NullablePointer[\\allowbaretypes\\ A]\n"
   "  new create(that: A) => compile_intrinsic\n"
-  "struct RuntimeOptions\n";
+  "struct RuntimeOptions\n"
+  "class CFixedSizedArrayValues[\\allowbaretypes\\ A, _size: USize, \\allowbaretypes\\ B: CFixedSizedArray[A, _size] #read] is Iterator[B->A]\n"
+  "  let _array : B\n"
+  "  var _i : USize\n"
+  "  new create(array : B) =>\n"
+  "  _array = array\n"
+  "  _i = 0\n"
+  "  fun has_next() : Bool => false\n"
+  "  fun ref next() : B->A ? => error\n"
+  "struct CFixedSizedArray[\\allowbaretypes\\ A, _size: USize]\n"
+  "fun values(): CFixedSizedArrayValues[A, _size, this->CFixedSizedArray[A, _size]]^ =>\n"
+  "  CFixedSizedArrayValues[A, _size, this->CFixedSizedArray[A, _size]](this)\n"
+  "  fun apply(index: USize) : this->A ? => error\n"
+  "  fun ref update(i: USize, value: A): A^ ? => error\n";
 
 
 void Main_runtime_override_defaults_oo(void* opt)

--- a/test/libponyc/value_dependent_types.cc
+++ b/test/libponyc/value_dependent_types.cc
@@ -9,6 +9,8 @@
 #define TEST_COMPILE_REACH(src) DO(test_compile(src, "reach"))
 #define TEST_ERROR_REACH(src) DO(test_error(src, "reach"))
 
+#define TEST_COMPILE_IR(src) DO(test_compile(src, "ir"))
+
 class VDTTest: public PassTest
 {};
 
@@ -627,3 +629,25 @@ TEST_F(VDTTest, VDTTypeUseReturnTypeLaterInAst)
   TEST_COMPILE_REACH(src);
 }
 
+TEST_F(VDTTest, RecursiveValueTypeParameterConstraintCompiles)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+
+    "  fun flatten[n: USize, \\allowbaretypes\\ A: CFixedSizedArray[CFixedSizedArray[A, n], n] #read](arrayin: CFixedSizedArray[CFixedSizedArray[A, n], n])\n"
+    "    : CFixedSizedArray[A, = n * 2]\n"
+    "  =>\n"
+    "    let rv: CFixedSizedArray[A, = n * 2] = CFixedSizedArray[A, = n * 2]\n"
+    "    var i: USize = 0\n"
+    "    for f in arrayin.values() do\n"
+    "      for g in f.values() do\n"
+    "        try\n"
+    "          rv(i)? = g\n"
+    "        end\n"
+    "      end\n"
+    "    end\n"
+    "    rv";
+
+  TEST_COMPILE_IR(src);
+}


### PR DESCRIPTION
Added handling of TK_VALUEFORMALPARAMREF in exact_type. It checks with ast_data if the reference as the same origin (same pointer). TK_VALUEFORMALARG is a failure because we don't know if it is the same structurally. This might have to be revisited, perhaps using an ast hash of the expression.

Added test cases for exact_type using TK_VALUEFORMALPARAMREF. Added a test case for recursive constraints using
CFixedSizedArray.