### PR TITLE
Allow all types to be annotated

### DIFF
--- a/src/libponyc/ast/bnfprint.c
+++ b/src/libponyc/ast/bnfprint.c
@@ -844,6 +844,7 @@ static void bnf_mark_used_rules(bnf_t* tree)
   }
 
 #define ANNOTATE(rule) OPT RULE("annotations", rule)
+#define ANNOTATE_NEXT(rule) OPT RULE("annotations", rule)
 
 #define DONE()  }
 

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -103,7 +103,7 @@ DEF(literal);
 DEF(comptime_expr);
   PRINT_INLINE();
   TOKEN(NULL, TK_COMPTIME);
-  ANNOTATE(annotations)
+  ANNOTATE(annotations);
   RULE("comptime expression value", seq);
   TERMINATE("comptime expression", TK_END);
   DONE();
@@ -183,7 +183,6 @@ DEF(bare);
 // ID [DOT ID] [typeargs] [CAP] [EPHEMERAL | ALIASED]
 DEF(nominal);
   AST_NODE(TK_NOMINAL);
-  ANNOTATE(annotations);
   TOKEN("name", TK_ID);
   IFELSE(TK_DOT,
     TOKEN("name", TK_ID),
@@ -310,6 +309,7 @@ DEF(viewpoint);
 
 // atomtype [viewpoint]
 DEF(type);
+  ANNOTATE_NEXT(annotations);
   RULE("type", atomtype);
   OPT_NO_DFLT RULE("viewpoint", viewpoint);
   DONE();

--- a/src/libponyc/ast/parserapi.c
+++ b/src/libponyc/ast/parserapi.c
@@ -167,11 +167,6 @@ static void annotation_builder(rule_state_t* state, ast_t* new_ast)
   pony_assert(state != NULL);
   pony_assert(new_ast != NULL);
 
-  if(strcmp(ast_name(ast_child(new_ast)), "byval") == 0)
-  {
-    int i = 0;
-  }
-
   ast_setannotation(state->ast, new_ast);
 }
 
@@ -525,11 +520,6 @@ ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
       state->fn_name,
       (state->deflt_id == TK_LEX_ERROR) ? "required" : "optional",
       (rule_set[1] == NULL) ? "" : "s", desc);
-  }
-
-  if(id == TK_BACKSLASH)
-  {
-    int i = 0;
   }
 
   builder_fn_t build_fn = NULL;

--- a/src/libponyc/ast/parserapi.c
+++ b/src/libponyc/ast/parserapi.c
@@ -122,6 +122,12 @@ static void default_builder(rule_state_t* state, ast_t* new_ast)
     return;
   }
 
+  if(state->annotate_next != NULL)
+  {
+    ast_setannotation(new_ast, state->annotate_next);
+    state->annotate_next = NULL;
+  }
+
   if(state->last_child == NULL)  // No valid last pointer
     ast_append(state->ast, new_ast);
   else  // Add new AST to end of children
@@ -161,7 +167,21 @@ static void annotation_builder(rule_state_t* state, ast_t* new_ast)
   pony_assert(state != NULL);
   pony_assert(new_ast != NULL);
 
+  if(strcmp(ast_name(ast_child(new_ast)), "byval") == 0)
+  {
+    int i = 0;
+  }
+
   ast_setannotation(state->ast, new_ast);
+}
+
+
+static void annotation_next_builder(rule_state_t* state, ast_t* new_ast)
+{
+  pony_assert(state != NULL);
+  pony_assert(new_ast != NULL);
+
+  state->annotate_next = new_ast;
 }
 
 
@@ -185,7 +205,7 @@ static void process_deferred_ast(parser_t* parser, rule_state_t* state)
 
 // Add the given AST to ours, handling deferment
 static void add_ast(parser_t* parser, rule_state_t* state, ast_t* new_ast,
-  builder_fn_t build_fn)
+  builder_fn_t build_fn, AnnotationMode annotation)
 {
   pony_assert(parser != NULL);
   pony_assert(state != NULL);
@@ -194,7 +214,7 @@ static void add_ast(parser_t* parser, rule_state_t* state, ast_t* new_ast,
 
   process_deferred_ast(parser, state);
 
-  if(state->ast == NULL)
+  if(state->ast == NULL && annotation != ANNOTATE_NEXT)
   {
     // The new AST is our only AST so far
     state->ast = new_ast;
@@ -227,7 +247,7 @@ void add_deferrable_ast(parser_t* parser, rule_state_t* state, token_id id,
     return;
   }
 
-  add_ast(parser, state, ast_new(token_for_pos, id), default_builder);
+  add_ast(parser, state, ast_new(token_for_pos, id), default_builder, ANNOTATE_NONE);
 }
 
 
@@ -301,7 +321,7 @@ static ast_t* propogate_error(parser_t* parser, rule_state_t* state)
  *    PARSE_OK
  */
 static ast_t* handle_found(parser_t* parser, rule_state_t* state,
-  ast_t* new_ast, builder_fn_t build_fn, bool* out_found)
+  ast_t* new_ast, builder_fn_t build_fn, bool* out_found, AnnotationMode annotation)
 {
   pony_assert(parser != NULL);
   pony_assert(state != NULL);
@@ -319,7 +339,7 @@ static ast_t* handle_found(parser_t* parser, rule_state_t* state,
   }
 
   if(new_ast != NULL)
-    add_ast(parser, state, new_ast, build_fn);
+    add_ast(parser, state, new_ast, build_fn, annotation);
 
   state->deflt_id = TK_LEX_ERROR;
   return PARSE_OK;
@@ -458,11 +478,11 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
 
       if(make_ast)
         return handle_found(parser, state, consume_token(parser),
-          default_builder, out_found);
+          default_builder, out_found, ANNOTATE_NONE);
 
       // AST not needed, discard token
       consume_token_no_ast(parser);
-      return handle_found(parser, state, NULL, NULL, out_found);
+      return handle_found(parser, state, NULL, NULL, out_found, ANNOTATE_NONE);
     }
   }
 
@@ -487,7 +507,7 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
  *    NULL to propagate a restarted error.
  */
 ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
-  const rule_t* rule_set, bool* out_found, bool annotate)
+  const rule_t* rule_set, bool* out_found, AnnotationMode annotate)
 {
   pony_assert(parser != NULL);
   pony_assert(state != NULL);
@@ -507,7 +527,25 @@ ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
       (rule_set[1] == NULL) ? "" : "s", desc);
   }
 
-  builder_fn_t build_fn = annotate ? annotation_builder : default_builder;
+  if(id == TK_BACKSLASH)
+  {
+    int i = 0;
+  }
+
+  builder_fn_t build_fn = NULL;
+  if(annotate == ANNOTATE_CURRENT)
+  {
+    build_fn = annotation_builder;
+  }
+  else if(annotate == ANNOTATE_NEXT)
+  {
+    build_fn = annotation_next_builder;
+  }
+  else
+  {
+    build_fn = default_builder;
+  }
+
   for(const rule_t* p = rule_set; *p != NULL; p++)
   {
     ast_t* rule_ast = (*p)(parser, &build_fn, desc);
@@ -519,7 +557,7 @@ ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
     {
       // Rule found
       parser->last_matched = desc;
-      return handle_found(parser, state, rule_ast, build_fn, out_found);
+      return handle_found(parser, state, rule_ast, build_fn, out_found, annotate);
     }
   }
 

--- a/src/libponyc/ast/parserapi.c
+++ b/src/libponyc/ast/parserapi.c
@@ -209,11 +209,18 @@ static void add_ast(parser_t* parser, rule_state_t* state, ast_t* new_ast,
 
   process_deferred_ast(parser, state);
 
+  // annotate_next is handled by build_fn = annotation_next_builder even if state->ast is NULL
   if(state->ast == NULL && annotation != ANNOTATE_NEXT)
   {
     // The new AST is our only AST so far
     state->ast = new_ast;
     state->last_child = NULL;
+
+    if(state->annotate_next != NULL)
+    {
+      ast_setannotation(new_ast, state->annotate_next);
+      state->annotate_next = NULL;
+    }
   }
   else
   {

--- a/src/libponyc/ast/parserapi.h
+++ b/src/libponyc/ast/parserapi.h
@@ -106,12 +106,12 @@ typedef ast_t* (*rule_t)(parser_t* parser, builder_fn_t *out_builder,
 #define PARSE_ERROR     ((ast_t*)2)   // A parse error has occurred
 #define RULE_NOT_FOUND  ((ast_t*)3)   // Sub item was not found
 
-enum AnnotationMode
+typedef enum
 {
   ANNOTATE_NONE,
   ANNOTATE_CURRENT,
   ANNOTATE_NEXT
-};
+}AnnotationMode;
 
 
 // Functions used by macros

--- a/src/libponyc/ast/parserapi.h
+++ b/src/libponyc/ast/parserapi.h
@@ -81,6 +81,7 @@ typedef struct rule_state_t
   const char* fn_name;  // Name of the current function, for tracing
   ast_t* ast;           // AST built for this rule
   ast_t* last_child;    // Last child added to current ast
+  ast_t* annotate_next; // saved annotation to be applied to the next rule
   const char* desc;     // Rule description (set by parent)
   token_id* restart;    // Restart token set, NULL for none
   token_id deflt_id;    // ID of node to create when an optional token or rule
@@ -105,6 +106,13 @@ typedef ast_t* (*rule_t)(parser_t* parser, builder_fn_t *out_builder,
 #define PARSE_ERROR     ((ast_t*)2)   // A parse error has occurred
 #define RULE_NOT_FOUND  ((ast_t*)3)   // Sub item was not found
 
+enum AnnotationMode
+{
+  ANNOTATE_NONE,
+  ANNOTATE_CURRENT,
+  ANNOTATE_NEXT
+};
+
 
 // Functions used by macros
 
@@ -120,7 +128,7 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
   bool* out_found);
 
 ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
-  const rule_t* rule_set, bool* out_found, bool annotate);
+  const rule_t* rule_set, bool* out_found, AnnotationMode annotate);
 
 void parse_set_next_flags(parser_t* parser, uint32_t flags);
 
@@ -157,7 +165,7 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
     const char* rule_desc) \
   { \
     (void)out_builder; \
-    rule_state_t state = {#rule, NULL, NULL, rule_desc, NULL, TK_LEX_ERROR, \
+    rule_state_t state = {#rule, NULL, NULL, NULL, rule_desc, NULL, TK_LEX_ERROR, \
       false, false, false, TK_NONE, 0, 0}
 
 
@@ -314,7 +322,7 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
 #define RULE(desc, ...) \
   { \
     static const rule_t rule_set[] = { __VA_ARGS__, NULL }; \
-    ast_t* r = parse_rule_set(parser, &state, desc, rule_set, NULL, false); \
+    ast_t* r = parse_rule_set(parser, &state, desc, rule_set, NULL, ANNOTATE_NONE); \
     if(r != PARSE_OK) return r; \
   }
 
@@ -399,7 +407,7 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
     { \
       state.deflt_id = TK_EOF; \
       ast_t* r = parse_rule_set(parser, &state, desc, rule_set, &found, \
-        false); \
+        ANNOTATE_NONE); \
       if(r != PARSE_OK) return r; \
     } \
   }
@@ -484,7 +492,21 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
     state.deflt_id = TK_EOF; \
     static const rule_t rule_set[] = { rule, NULL }; \
     ast_t* r = parse_rule_set(parser, &state, "annotations", rule_set, NULL, \
-      true); \
+      ANNOTATE_CURRENT); \
+    if(r != PARSE_OK) return r; \
+  }
+
+ /** Annotate the next AST with another AST node from an arbitrary rule.
+  *
+  * Example:
+  *    ANNOTATE_NEXT(annotations)
+  */
+#define ANNOTATE_NEXT(rule) \
+  { \
+    state.deflt_id = TK_EOF; \
+    static const rule_t rule_set[] = { rule, NULL }; \
+    ast_t* r = parse_rule_set(parser, &state, "annotations", rule_set, NULL, \
+      ANNOTATE_NEXT); \
     if(r != PARSE_OK) return r; \
   }
 


### PR DESCRIPTION
Previously only nominal types were allowed to be annotated. Now all types in the type rule can be annotated. Because ANNOTATE(rule) can only annotate the previous rule a new ANNOTATE_NEXT(rule) was added in order to annotate the upcoming type rule.

This enables grouped types to be annotated as well such as tuples and union/intersect types.