### PR TITLE
Add direct unit tests for partial/non-partial method name mangling (#…

### DIFF
--- a/test/libponyc/reach.cc
+++ b/test/libponyc/reach.cc
@@ -6,6 +6,7 @@
 
 #include "util.h"
 
+#include <cstring>
 #include <memory>
 
 
@@ -345,4 +346,294 @@ TEST_F(ReachTest, UnionReachedMethod)
   }
 
   ASSERT_TRUE(found);
+}
+
+// Return the mangled name of one reached method called `method_name` on the
+// reached type `type_name`, or NULL if the type or method wasn't reached.
+//
+// A `box`/`tag` fun is reached under several receiver caps (box/ref/val), each
+// a distinct entry in `r_mangled` with a cap-PREFIXED mangle (`box_f_...` vs
+// `val_f_...`) — so the entries do NOT share a full mangled name and the one
+// `reach_mangled_next` returns first is an arbitrary pick among them. That is
+// fine for the mangling tests below, which only inspect the mangle SUFFIX (the
+// `_p` marker, the trailing result-type character) and cross-method
+// relationships, both invariant across the cap variants. Do not use this to
+// assert a full mangled string.
+static const char* any_mangled_name(reach_t* r, const char* type_name,
+  const char* method_name)
+{
+  reach_type_t* t = reach_type_name(r, type_name);
+
+  if(t == NULL)
+    return NULL;
+
+  reach_method_name_t* n = reach_method_name(t, stringtab(method_name));
+
+  if(n == NULL)
+    return NULL;
+
+  size_t i = HASHMAP_BEGIN;
+  reach_method_t* m = reach_mangled_next(&n->r_mangled, &i);
+
+  if(m == NULL)
+    return NULL;
+
+  return m->mangled_name;
+}
+
+static bool ends_with(const char* s, const char* suffix)
+{
+  size_t s_len = strlen(s);
+  size_t suffix_len = strlen(suffix);
+
+  return (s_len >= suffix_len) &&
+    (strcmp(s + (s_len - suffix_len), suffix) == 0);
+}
+
+// Partiality is part of a method's calling convention (a partial method returns
+// `{T, i1}`, a non-partial one returns `T`), so make_mangled_name encodes it: a
+// partial method gets a trailing `_p` and therefore mangles distinctly, lands
+// in its own vtable slot, and never shares a slot's calling convention with a
+// non-partial method. This guards that encoding directly rather than only
+// through the dispatch behaviour observed by full-program tests.
+TEST_F(ReachTest, PartialAndNonPartialMangleDistinctly)
+{
+  const char* src =
+    "class C1\n"
+    "  fun f() ? => error\n"
+
+    "class C2\n"
+    "  fun f() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let c1: C1 = C1\n"
+    "    let c2: C2 = C2\n"
+    "    try c1.f()? end\n"
+    "    c2.f()";
+
+  TEST_COMPILE(src, "reach");
+
+  reach_t* reach = compile->reach;
+
+  const char* partial = any_mangled_name(reach, "C1", "f");
+  const char* non_partial = any_mangled_name(reach, "C2", "f");
+
+  ASSERT_NE(partial, (void*)NULL);
+  ASSERT_NE(non_partial, (void*)NULL);
+
+  // Same signature, distinct mangle: the whole point of the encoding.
+  ASSERT_STRNE(partial, non_partial);
+
+  // The partial method carries the marker; the non-partial one does not.
+  ASSERT_TRUE(ends_with(partial, "_p"));
+  ASSERT_FALSE(ends_with(non_partial, "_p"));
+}
+
+// Bare methods (@-functions) are excluded from the partiality split: a bare
+// partial function aborts on error rather than returning `{T, i1}`, so its
+// calling convention does not depend on partiality and it must not get the `_p`
+// marker. A bare partial method and a bare non-partial method with the same
+// signature therefore mangle identically.
+TEST_F(ReachTest, BareMethodsNotSplitByPartiality)
+{
+  const char* src =
+    "primitive P1\n"
+    "  fun @g() ? => error\n"
+
+    "primitive P2\n"
+    "  fun @g() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try P1.g()? end\n"
+    "    P2.g()";
+
+  TEST_COMPILE(src, "reach");
+
+  reach_t* reach = compile->reach;
+
+  const char* bare_partial = any_mangled_name(reach, "P1", "g");
+  const char* bare_non_partial = any_mangled_name(reach, "P2", "g");
+
+  ASSERT_NE(bare_partial, (void*)NULL);
+  ASSERT_NE(bare_non_partial, (void*)NULL);
+
+  // Bareness, not partiality, decides the slot: neither carries the marker...
+  ASSERT_FALSE(ends_with(bare_partial, "_p"));
+  ASSERT_FALSE(ends_with(bare_non_partial, "_p"));
+
+  // ...so the two share a mangled name despite differing in partiality. (Bare
+  // methods have a single r_mangled entry with no cap prefix, so a full-string
+  // comparison is sound here.)
+  ASSERT_STREQ(bare_partial, bare_non_partial);
+}
+
+// The `_p` marker is collision-free only because no non-partial method's mangle
+// ends in 'p': a non-internal method's mangle ends in its result type's mangle,
+// and every type mangle ends in a character from a fixed set that excludes 'p'
+// (see the collision-free note in make_mangled_name). This pins that documented
+// mapping — each numeric type, Bool, and an object type maps to its expected
+// terminal character — so a change that remapped one of these onto 'p' fails
+// here. (It does NOT catch a brand-new type whose mangle ends in 'p'; that
+// broader guard, over every reached type including recursively-built tuple
+// mangles, is NoReachedTypeMangleEndsInMarker below.)
+TEST_F(ReachTest, NonPartialMangleNeverEndsInMarker)
+{
+  const char* src =
+    "primitive R\n"
+    "  fun i8(): I8 => 0\n"
+    "  fun i16(): I16 => 0\n"
+    "  fun i32(): I32 => 0\n"
+    "  fun i64(): I64 => 0\n"
+    "  fun i128(): I128 => 0\n"
+    "  fun ilong(): ILong => 0\n"
+    "  fun isize(): ISize => 0\n"
+    "  fun u8(): U8 => 0\n"
+    "  fun u16(): U16 => 0\n"
+    "  fun u32(): U32 => 0\n"
+    "  fun u64(): U64 => 0\n"
+    "  fun u128(): U128 => 0\n"
+    "  fun ulong(): ULong => 0\n"
+    "  fun usize(): USize => 0\n"
+    "  fun f32(): F32 => 0\n"
+    "  fun f64(): F64 => 0\n"
+    "  fun bool(): Bool => true\n"
+    "  fun obj(): R => R\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    R.i8() ; R.i16() ; R.i32() ; R.i64() ; R.i128()\n"
+    "    R.ilong() ; R.isize()\n"
+    "    R.u8() ; R.u16() ; R.u32() ; R.u64() ; R.u128()\n"
+    "    R.ulong() ; R.usize()\n"
+    "    R.f32() ; R.f64() ; R.bool() ; R.obj()";
+
+  TEST_COMPILE(src, "reach");
+
+  reach_t* reach = compile->reach;
+
+  struct { const char* method; char terminal; } cases[] = {
+    {"i8", 'c'}, {"i16", 's'}, {"i32", 'i'}, {"i64", 'w'}, {"i128", 'q'},
+    {"ilong", 'l'}, {"isize", 'z'},
+    {"u8", 'C'}, {"u16", 'S'}, {"u32", 'I'}, {"u64", 'W'}, {"u128", 'Q'},
+    {"ulong", 'L'}, {"usize", 'Z'},
+    {"f32", 'f'}, {"f64", 'd'},
+    {"bool", 'b'}, {"obj", 'o'}
+  };
+
+  for(size_t i = 0; i < (sizeof(cases) / sizeof(cases[0])); i++)
+  {
+    const char* mangled = any_mangled_name(reach, "R", cases[i].method);
+    ASSERT_NE(mangled, (void*)NULL) << "method " << cases[i].method;
+
+    size_t len = strlen(mangled);
+    ASSERT_GT(len, (size_t)0) << "method " << cases[i].method;
+
+    char terminal = mangled[len - 1];
+
+    // Pins the documented type-mangle character...
+    EXPECT_EQ(terminal, cases[i].terminal)
+      << "method " << cases[i].method << " mangled as " << mangled;
+
+    // ...which, in particular, is never the marker character.
+    EXPECT_NE(terminal, 'p')
+      << "method " << cases[i].method << " mangled as " << mangled;
+  }
+}
+
+// The collision-free guarantee rests on a reciprocal invariant documented at
+// the t->mangle assignments in reach.c ("no t->mangle value may be, or end in,
+// 'p'"): the partial marker `_p` is appended last, so it can only stay distinct
+// from a non-partial mangle if no type mangle — the final segment of a
+// non-partial method's mangle — ends in 'p'. NonPartialMangleNeverEndsInMarker
+// pins the documented per-type characters but, being enumerative, can't catch a
+// newly-added type whose mangle ends in 'p'. This guards the invariant at its
+// source: every reached type's mangle must not end in 'p'. The tuple result
+// below forces a reached tuple type, exercising the recursively-built tuple
+// mangle that the collision-free note calls out explicitly.
+TEST_F(ReachTest, NoReachedTypeMangleEndsInMarker)
+{
+  const char* src =
+    "primitive R\n"
+    "  fun pair(): (I8, R) => (0, R)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    R.pair()";
+
+  TEST_COMPILE(src, "reach");
+
+  reach_t* reach = compile->reach;
+
+  // A tuple type must actually be reached, else the recursive-mangle path this
+  // test exists to cover wouldn't be exercised.
+  bool saw_tuple = false;
+
+  size_t i = HASHMAP_BEGIN;
+  reach_type_t* t;
+  while((t = reach_types_next(&reach->types, &i)) != NULL)
+  {
+    ASSERT_NE(t->mangle, (void*)NULL) << "type " << t->name;
+
+    size_t len = strlen(t->mangle);
+
+    if(len > 0)
+      EXPECT_NE(t->mangle[len - 1], 'p')
+        << "type " << t->name << " mangled as " << t->mangle;
+
+    if(t->underlying == TK_TUPLETYPE)
+      saw_tuple = true;
+  }
+
+  ASSERT_TRUE(saw_tuple);
+}
+
+// make_mangled_name notes that 'p' can appear EARLIER in a mangle without
+// breaking the marker: trace_kind_append emits 'p' for a primitive parameter
+// (constructors and behaviors carry trace-kind characters), always just before
+// that parameter's own type mangle and never as the final character. Only the
+// terminal character decides partiality, so an interior 'p' is harmless. This
+// exercises that rule: a constructor with a primitive parameter mangles with an
+// interior 'p', yet the non-partial one does not end in 'p' (so it can't
+// collide with a partial mangle) and the partial one is still kept distinct by
+// the trailing marker.
+TEST_F(ReachTest, InteriorTraceKindMarkerDoesNotCollide)
+{
+  const char* src =
+    "class C\n"
+    "  new safe(x: U8) => None\n"
+    "  new risky(x: U8) ? => error\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    C.safe(0)\n"
+    "    try C.risky(0)? end";
+
+  TEST_COMPILE(src, "reach");
+
+  reach_t* reach = compile->reach;
+
+  const char* non_partial = any_mangled_name(reach, "C", "safe");
+  const char* partial = any_mangled_name(reach, "C", "risky");
+
+  ASSERT_NE(non_partial, (void*)NULL);
+  ASSERT_NE(partial, (void*)NULL);
+
+  // trace_kind emitted 'p' for the U8 parameter, sitting before the terminal
+  // character (the method names and the U8/result mangles contain no 'p', so
+  // this 'p' can only be the trace-kind character).
+  const char* np_p = strchr(non_partial, 'p');
+  ASSERT_NE(np_p, (void*)NULL);
+  ASSERT_LT(np_p, non_partial + (strlen(non_partial) - 1));
+
+  ASSERT_NE(strchr(partial, 'p'), (void*)NULL);
+
+  // The non-partial mangle carries an interior 'p' yet does not end in 'p', so
+  // it can never collide with a partial mangle...
+  ASSERT_FALSE(ends_with(non_partial, "_p"));
+
+  // ...while the partial one is still marked, despite also carrying the
+  // interior trace-kind 'p'.
+  ASSERT_TRUE(ends_with(partial, "_p"));
 }


### PR DESCRIPTION
…5419)

The partiality encoding in make_mangled_name (the trailing `_p` that keeps partial and non-partial methods in separate vtable slots) was covered only indirectly, through full-program tests that observe correct dispatch. These tests guard the mangling invariants at the source: partial and non-partial methods mangle distinctly, bare methods are exempt from the split, and the marker stays collision-free because no reached type's mangle ends in 'p'.

Closes #5394