### PR TITLE
Fix unnecessary reallocations when building small Strings and Arrays …

### DIFF
--- a/.release-notes/fix-small-string-array-reallocations.md
+++ b/.release-notes/fix-small-string-array-reallocations.md
@@ -1,0 +1,5 @@
+## Fix unnecessary reallocations when building small Strings and Arrays
+
+Building a small `String` or `Array` incrementally — appending or pushing through its first several elements — triggered repeated reallocations and copies, even though every one of those sizes fit within the single block the runtime allocator had already handed out. The collections now record the capacity of the block they were given, so a small `String` or `Array` allocates once and does not reallocate again until it genuinely outgrows that block.
+
+A side effect is that `space()` may report a larger capacity than before for a small collection; the extra capacity is memory the allocator had already reserved, so a program's memory use is unchanged.

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -63,21 +63,25 @@ class Array[\allowbaretypes, noconstraintcheck\ A] is Seq[A]
   Different data types require different amounts of memory. Array[U64] with size
   of 6 will take more memory than an Array[U8] of the same size.
 
-  When creating an Array or adding more elements will calculate the next power
-  of 2 of the requested number of elements and allocate that much space, with a
-  lower bound of space for 8 elements.
+  When creating an Array or adding more elements, the space allocated is the
+  next power of 2 of the requested number of elements, with a lower bound: the
+  larger of 8 elements and the number of elements that fill the runtime
+  allocator's minimum block (32 bytes). For small element types the block bound
+  dominates — an `Array[U8]` always has space for at least 32 elements and an
+  `Array[U16]` at least 16 — while for elements of 4 bytes or more the 8-element
+  bound applies.
 
-  Here's a few examples of the space allocated when initialising an Array with
-  various number of elements:
+  Here's a few examples of the space allocated for an `Array[U8]` with various
+  numbers of elements:
 
   | size | space |
   |------|-------|
   | 0    | 0     |
-  | 1    | 8     |
-  | 8    | 8     |
-  | 9    | 16    |
-  | 16   | 16    |
-  | 17   | 32    |
+  | 1    | 32    |
+  | 32   | 32    |
+  | 33   | 64    |
+  | 64   | 64    |
+  | 65   | 128   |
 
   Call the `compact()` method to ask the GC to reclaim unused space. There are
   no guarantees that the GC will actually reclaim any space.
@@ -93,7 +97,7 @@ class Array[\allowbaretypes, noconstraintcheck\ A] is Seq[A]
     _size = 0
 
     if len > 0 then
-      _alloc = len.next_pow2().max(len).max(8)
+      _alloc = len.next_pow2().max(len).max(8).max(Pointer[A].min_alloc())
       _ptr = Pointer[A].alloc(_alloc)
     else
       _alloc = 0
@@ -107,7 +111,7 @@ class Array[\allowbaretypes, noconstraintcheck\ A] is Seq[A]
     _size = len
 
     if len > 0 then
-      _alloc = len.next_pow2().max(len).max(8)
+      _alloc = len.next_pow2().max(len).max(8).max(Pointer[A].min_alloc())
       _ptr = Pointer[A].alloc(_alloc)
 
       var i: USize = 0
@@ -174,10 +178,12 @@ class Array[\allowbaretypes, noconstraintcheck\ A] is Seq[A]
   fun ref reserve(len: USize) =>
     """
     Reserve space for len elements, including whatever elements are already in
-    the array. Array space grows geometrically.
+    the array. Array space grows geometrically. The space reserved is never
+    smaller than the runtime allocator's minimum block, so for small element
+    types it may exceed len.
     """
     if _alloc < len then
-      _alloc = len.next_pow2().max(len).max(8)
+      _alloc = len.next_pow2().max(len).max(8).max(_ptr.min_alloc())
       _ptr = _ptr.realloc(_alloc, _size)
     end
 
@@ -193,8 +199,9 @@ class Array[\allowbaretypes, noconstraintcheck\ A] is Seq[A]
     request may be ignored.
     """
     if _size <= (512 / _ptr._element_size()) then
-      if _size.next_pow2() != _alloc.next_pow2() then
-        _alloc = _size.next_pow2()
+      let target = _size.next_pow2().max(_ptr.min_alloc())
+      if target < _alloc then
+        _alloc = target
         let old_ptr = _ptr = Pointer[A].alloc(_alloc)
         old_ptr._copy_to(_ptr.convert[A!](), _size)
       end

--- a/packages/builtin/pointer.pony
+++ b/packages/builtin/pointer.pony
@@ -82,6 +82,17 @@ struct Pointer[\allowbaretypes, noconstraintcheck\ A]
     """
     compile_intrinsic
 
+  fun tag min_alloc(): USize =>
+    """
+    Return how many elements fill the runtime allocator's minimum block
+    (`HEAP_MIN / element_size`), but always at least one. A smaller allocation is
+    rounded up to the same block by the allocator anyway, so String and Array
+    use this as a capacity floor (in their constructors, reserve, and compact)
+    to avoid recording less space than the block actually provides (which would
+    force pointless reallocations as the collection grows).
+    """
+    compile_intrinsic
+
   fun ref _insert(n: USize, len: USize): Pointer[A] =>
     """
     Creates space for n new elements at the head, moving following elements.

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -56,7 +56,7 @@ actor Main
     An empty string. Enough space for len bytes is reserved.
     """
     _size = 0
-    _alloc = len.min(len.max_value() - 1) + 1
+    _alloc = (len.min(len.max_value() - 1) + 1).max(Pointer[U8].min_alloc())
     _ptr = Pointer[U8].alloc(_alloc)
     _set(0, 0)
 
@@ -131,14 +131,15 @@ actor Main
     """
     if str.is_null() then
       _size = 0
-      _alloc = 1
+      _alloc = Pointer[U8].min_alloc()
       _ptr = Pointer[U8].alloc(_alloc)
       _set(0, 0)
     else
       _size = len
-      _alloc = _size + 1
+      _alloc = (_size + 1).max(Pointer[U8].min_alloc())
       _ptr = Pointer[U8].alloc(_alloc)
-      str._copy_to(_ptr, _alloc)
+      // copy only the content (plus terminator slot); _alloc may be larger.
+      str._copy_to(_ptr, _size + 1)
     end
 
   new copy_cstring(str: Pointer[U8] box) =>
@@ -150,7 +151,7 @@ actor Main
     """
     if str.is_null() then
       _size = 0
-      _alloc = 1
+      _alloc = Pointer[U8].min_alloc()
       _ptr = Pointer[U8].alloc(_alloc)
       _set(0, 0)
     else
@@ -161,9 +162,11 @@ actor Main
       end
 
       _size = i
-      _alloc = i + 1
+
+      _alloc = (i + 1).max(Pointer[U8].min_alloc())
       _ptr = Pointer[U8].alloc(_alloc)
-      str._copy_to(_ptr, _alloc)
+      // copy only the content (plus terminator slot); _alloc may be larger.
+      str._copy_to(_ptr, i + 1)
     end
 
   new from_utf32(value: U32) =>
@@ -172,7 +175,7 @@ actor Main
     """
     let encoded = _UTF32Encoder.encode(value)
     _size = encoded._1
-    _alloc = _size + 1
+    _alloc = (_size + 1).max(Pointer[U8].min_alloc())
     _ptr = Pointer[U8].alloc(_alloc)
     _set(0, encoded._2)
     if encoded._1 > 1 then
@@ -290,13 +293,15 @@ actor Main
   fun ref reserve(len: USize) =>
     """
     Reserve space for len bytes. An additional byte will be reserved for the
-    null terminator.
+    null terminator. The space reserved is never smaller than the runtime
+    allocator's minimum block (32 bytes), so a small string may reserve more
+    than requested.
     """
     if _alloc <= len then
       let max = len.max_value() - 1
       let min_alloc = len.min(max) + 1
       if min_alloc <= (max / 2) then
-        _alloc = min_alloc.next_pow2()
+        _alloc = min_alloc.next_pow2().max(_ptr.min_alloc())
       else
         _alloc = min_alloc.min(max)
       end
@@ -309,8 +314,9 @@ actor Main
     request may be ignored. The string is returned to allow call chaining.
     """
     if (_size + 1) <= 512 then
-      if (_size + 1).next_pow2() != _alloc.next_pow2() then
-        _alloc = (_size + 1).next_pow2()
+      let target = (_size + 1).next_pow2().max(_ptr.min_alloc())
+      if target < _alloc then
+        _alloc = target
         let old_ptr = _ptr = Pointer[U8].alloc(_alloc)
         old_ptr._copy_to(_ptr, _size)
         _set(_size, 0)

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -27,11 +27,14 @@ actor \nodoc\ Main is TestList
     test(_TestArrayAppend)
     test(_TestArrayChop)
     test(_TestArrayChopWithPush)
+    test(_TestArrayCompactMinAlloc)
+    test(_TestArrayCreateMinAlloc)
     test(_TestArrayConcat)
     test(_TestArrayFind)
     test(_TestArrayFromCPointer)
     test(_TestArrayCopyTo)
     test(_TestArrayInsert)
+    test(_TestArrayReserveMinAlloc)
     test(_TestArraySlice)
     test(_TestArraySwapElements)
     test(_TestArrayTrim)
@@ -61,6 +64,8 @@ actor \nodoc\ Main is TestList
     test(_TestStringAdd)
     test(_TestStringChop)
     test(_TestStringChopWithPush)
+    test(_TestStringCompactMinAlloc)
+    test(_TestStringCreateMinAlloc)
     test(_TestStringCompare)
     test(_TestStringConcatOffsetLen)
     test(_TestStringContains)
@@ -77,6 +82,7 @@ actor \nodoc\ Main is TestList
     test(_TestStringRemove)
     test(_TestStringRepeatStr)
     test(_TestStringReplace)
+    test(_TestStringReserveMinAlloc)
     test(_TestStringRFind)
     test(_TestStringRstrip)
     test(_TestStringRunes)
@@ -1236,6 +1242,154 @@ class \nodoc\ iso _TestStringTruncate is UnitTest
     h.assert_true(s.is_null_terminated())
     h.assert_eq[USize](3, s.size())
     h.assert_eq[String]("111", s.clone())
+
+class \nodoc\ iso _TestStringReserveMinAlloc is UnitTest
+  """
+  reserve floors a String's capacity at the runtime allocator's minimum block
+  (HEAP_MIN, 32 bytes), so a small reservation does not record a capacity below
+  the block the allocator actually returns.
+  """
+  fun name(): String => "builtin/String.reserve_min_alloc"
+
+  fun apply(h: TestHelper) =>
+    let s = String
+    s.reserve(1)
+    // _alloc is floored to 32. space() is 31 or 32 depending on whether the
+    // (uninitialised) null-terminator byte reads as 0, so bound both sides: the
+    // lower bound catches a missing floor (without it _alloc would be 2), the
+    // upper bound catches over-allocation.
+    h.assert_true(s.space() >= 31)
+    h.assert_true(s.space() <= 32)
+
+class \nodoc\ iso _TestStringCompactMinAlloc is UnitTest
+  """
+  compact floors a String's capacity at the minimum block, shrinks genuine
+  over-allocations, and never grows the allocation.
+  """
+  fun name(): String => "builtin/String.compact_min_alloc"
+
+  fun apply(h: TestHelper) =>
+    // A large over-allocation shrinks toward the block, but not below it.
+    let over = String
+    over.reserve(200)             // _alloc = 256
+    over.append("abc")
+    let over_before = over.space()
+    over.compact()
+    h.assert_true(over.space() < over_before)
+    h.assert_true(over.space() >= 31)
+
+    // Already within the block: compact must not grow.
+    let small = String
+    small.reserve(1)              // _alloc = 32
+    small.append("abc")
+    let small_before = small.space()
+    small.compact()
+    h.assert_true(small.space() <= small_before)
+    h.assert_true(small.space() >= 31)
+
+    // Non-power-of-two _alloc from a middle trim_in_place: compact must not grow
+    // it. Guards the `target < _alloc` guard against regressing to `!=`, which
+    // would grow this case (40 -> 64).
+    let trimmed = String
+    var i: USize = 0
+    while i < 50 do trimmed.push('x'); i = i + 1 end
+    trimmed.trim_in_place(5, 45)  // middle trim leaves _alloc = 40 (not pow2)
+    let trimmed_before = trimmed.space()
+    trimmed.compact()
+    h.assert_true(trimmed.space() <= trimmed_before)
+
+class \nodoc\ iso _TestArrayReserveMinAlloc is UnitTest
+  """
+  reserve floors an Array's capacity at the minimum block (32 bytes). Small
+  element types are raised to fill the block; element types whose existing
+  8-element minimum already meets or exceeds the block are unchanged.
+  """
+  fun name(): String => "builtin/Array.reserve_min_alloc"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[USize](32, Array[U8].>reserve(1).space())   // raised 8 -> 32
+    h.assert_eq[USize](16, Array[U16].>reserve(1).space())  // raised 8 -> 16
+    h.assert_eq[USize](8, Array[U32].>reserve(1).space())   // unchanged (= 8)
+    h.assert_eq[USize](8, Array[U64].>reserve(1).space())   // unchanged (4 < 8)
+
+class \nodoc\ iso _TestArrayCompactMinAlloc is UnitTest
+  """
+  compact floors an Array's capacity at the minimum block, shrinks genuine
+  over-allocations, and never grows — including a non-power-of-two capacity left
+  by trim_in_place.
+  """
+  fun name(): String => "builtin/Array.compact_min_alloc"
+
+  fun apply(h: TestHelper) =>
+    // A large over-allocation shrinks to the block, not below it.
+    let over = Array[U8]
+    over.reserve(200)             // _alloc = 256
+    over.push(0)
+    let over_before = over.space()
+    over.compact()
+    h.assert_true(over.space() < over_before)
+    h.assert_eq[USize](32, over.space())
+
+    // Already at the block: compact must not grow.
+    let small = Array[U8]
+    small.reserve(1)              // _alloc = 32
+    small.push(0)
+    h.assert_eq[USize](32, small.space())
+    small.compact()
+    h.assert_eq[USize](32, small.space())
+
+    // Non-power-of-two _alloc from trim_in_place: compact must not grow it.
+    // Guards the `target < _alloc` guard against regressing to `!=`, which would
+    // grow this case (48 -> 64).
+    let trimmed = Array[U8]
+    trimmed.reserve(40)           // _alloc = 64
+    var i: USize = 0
+    while i < 64 do trimmed.push(0); i = i + 1 end
+    trimmed.trim_in_place(16, 64) // _alloc -> 48 (not a power of two), size 48
+    let trimmed_before = trimmed.space()
+    h.assert_eq[USize](48, trimmed_before)
+    trimmed.compact()
+    h.assert_true(trimmed.space() <= trimmed_before)
+
+    // Non-power-of-two _alloc with small content: compact shrinks it to the
+    // block (the shrink branch reached from a non-power-of-two capacity).
+    let shrink = Array[U8]
+    shrink.reserve(200)           // _alloc = 256
+    var j: USize = 0
+    while j < 200 do shrink.push(0); j = j + 1 end
+    shrink.trim_in_place(190, 200) // _alloc -> 66 (not a power of two), size 10
+    h.assert_eq[USize](66, shrink.space())
+    shrink.compact()
+    h.assert_eq[USize](32, shrink.space()) // shrank from 66 to the 32-byte block
+
+class \nodoc\ iso _TestStringCreateMinAlloc is UnitTest
+  """
+  String's size-taking constructor floors capacity at the allocator's minimum
+  block (32 bytes), the same as reserve.
+  """
+  fun name(): String => "builtin/String.create_min_alloc"
+
+  fun apply(h: TestHelper) =>
+    // String(1) allocates a 32-byte block and is null-terminated, so space() is
+    // _alloc - 1 = 31. Without the floor _alloc would be 2, giving space() 1.
+    h.assert_eq[USize](31, String(1).space())
+    // from_utf32 (a fresh copy/encode constructor) floors too.
+    h.assert_eq[USize](31, String.from_utf32('a').space())
+
+class \nodoc\ iso _TestArrayCreateMinAlloc is UnitTest
+  """
+  Array's size-taking constructors (create, init) floor capacity at the minimum
+  block (32 bytes), the same as reserve. An empty array allocates nothing.
+  """
+  fun name(): String => "builtin/Array.create_min_alloc"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[USize](32, Array[U8](1).space())          // raised 8 -> 32
+    h.assert_eq[USize](16, Array[U16](1).space())         // raised 8 -> 16
+    h.assert_eq[USize](8, Array[U32](1).space())          // unchanged (= 8)
+    h.assert_eq[USize](8, Array[U64](1).space())          // unchanged (4 < 8)
+    h.assert_eq[USize](32, Array[U8].init(0, 1).space())  // init floors too
+    h.assert_eq[USize](0, Array[U8].space())              // empty: no allocation
 
 class \nodoc\ iso _TestStringChop is UnitTest
   """

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -28,6 +28,7 @@ actor \nodoc\ Main is TestList
     test(_TestFileLinesSingleLine)
     test(_TestFileLongLine)
     test(_TestFileMixedWriteQueue)
+    test(_TestFileReadStringSmall)
     test(_TestFileOpen)
     test(_TestFileOpenError)
     test(_TestFileOpenWrite)
@@ -461,6 +462,23 @@ class \nodoc\ iso _TestFileEOF is UnitTest
       let line2 = file.read_string(1)
       h.assert_eq[USize](line2.size(), 0, "Read beyond EOF without error!")
       h.assert_true(file.errno() is FileEOF)
+    end
+    filepath.remove()
+
+class \nodoc\ iso _TestFileReadStringSmall is UnitTest
+  fun name(): String => "files/File.read_string-small"
+  fun apply(h: TestHelper) =>
+    let path = "tmp.read_string_small"
+    let filepath = FilePath(FileAuth(h.env.root), path)
+    with file = File(filepath) do
+      // 40 bytes, larger than the allocator's 32-byte minimum block.
+      file.write("0123456789012345678901234567890123456789")
+      file.sync()
+      file.seek_start(0)
+      // read_string(5) must return exactly 5 bytes, not the buffer's capacity.
+      let chunk = file.read_string(5)
+      h.assert_eq[USize](5, chunk.size())
+      h.assert_eq[String]("01234", consume chunk)
     end
     filepath.remove()
 

--- a/packages/files/file.pony
+++ b/packages/files/file.pony
@@ -256,9 +256,9 @@ class File
       let result = recover String(len) end
 
       let r = (ifdef windows then
-        @_read(_fd, result.cpointer(), result.space().i32())
+        @_read(_fd, result.cpointer(), len.i32())
       else
-        @read(_fd, result.cpointer(), result.space())
+        @read(_fd, result.cpointer(), len)
       end).isize()
 
       match r

--- a/packages/format/format.pony
+++ b/packages/format/format.pony
@@ -69,7 +69,7 @@ primitive Format
       match \exhaustive\ align
       | AlignLeft =>
         s.append(str)
-        for i in Range(s.size(), s.space()) do
+        for i in Range(s.size(), len) do
           s.push_utf32(fill)
         end
       | AlignRight =>
@@ -83,7 +83,7 @@ primitive Format
           s.push_utf32(fill)
         end
         s.append(str)
-        for i in Range(s.size(), s.space()) do
+        for i in Range(s.size(), len) do
           s.push_utf32(fill)
         end
       end

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -319,6 +319,23 @@ static void pointer_element_size(compile_t* c, reach_type_t* t,
   codegen_finishfun(c);
 }
 
+static void pointer_min_alloc(compile_t* c, reach_type_t* t,
+  compile_type_t* t_elem)
+{
+  FIND_METHOD("min_alloc", TK_NONE, c->opt);
+  start_function(c, t, m, c->intptr, &c_t->use_type, 1);
+
+  // The smallest element count whose byte size reaches the allocator's minimum
+  // block (HEAP_MIN). One element for zero-sized or larger-than-block elements;
+  // otherwise HEAP_MIN / element size.
+  size_t size = (size_t)LLVMABISizeOfType(c->target_data, t_elem->mem_type);
+  size_t min = ((size == 0) || (size > HEAP_MIN)) ? 1 : (HEAP_MIN / size);
+  LLVMValueRef l_min = LLVMConstInt(c->intptr, min, false);
+
+  genfun_build_ret(c, l_min);
+  codegen_finishfun(c);
+}
+
 static void pointer_insert(compile_t* c, reach_type_t* t,
   compile_type_t* t_elem)
 {
@@ -533,6 +550,7 @@ void genprim_pointer_methods(compile_t* c, reach_type_t* t)
   pointer_update(c, t, t_elem);
   BOX_FUNCTION(pointer_pointer_at_index, c_box_args);
   pointer_element_size(c, t, c_t_elem);
+  pointer_min_alloc(c, t, c_t_elem);
   pointer_insert(c, t, c_t_elem);
   pointer_delete(c, t, t_elem);
   BOX_FUNCTION(pointer_copy_to, c_box_args);

--- a/src/libponyc/ctfe/ctfe_value_pointer.cc
+++ b/src/libponyc/ctfe/ctfe_value_pointer.cc
@@ -9,6 +9,7 @@
 
 #include "../ast/ast.h"
 #include "../codegen/genname.h"
+#include "../../libponyrt/mem/heap.h"
 
 
 using namespace std;
@@ -300,6 +301,14 @@ bool CtfeValuePointer::run_method(pass_opt_t* opt, errorframe_t* errors, ast_t* 
       const CtfeValuePointer& r = recv.get_pointer();
       bool n = r.m_array == nullptr;
       result = CtfeValue(CtfeValueBool(n), res_type);
+      return true;
+    }
+    else if(method_name == "min_alloc")
+    {
+      CtfeValuePointer& rec_val = recv.get_pointer();
+      size_t elem_size = rec_val.get_elem_size();
+      size_t min = ((elem_size == 0) || (elem_size > HEAP_MIN)) ? 1 : (HEAP_MIN / elem_size);
+      result = CtfeValue(min, res_type);
       return true;
     }
   }

--- a/src/libponyc/ctfe/ctfe_value_pointer.h
+++ b/src/libponyc/ctfe/ctfe_value_pointer.h
@@ -63,6 +63,7 @@ public:
   uint8_t *get_cpointer() const { return m_array; }
   ast_t* get_pointer_type_ast() const { return m_pointer_type; }
   ast_t* get_pointer_elem_type_ast() const { return m_elem_pointer_type; }
+  size_t get_elem_size() const { return m_elem_size; }
 
   CtfeValueBool eq(const CtfeValuePointer& b) const { return CtfeValueBool(m_array == b.m_array); }
   CtfeValueBool ne(const CtfeValuePointer& b) const { return CtfeValueBool(m_array != b.m_array); }

--- a/src/libponyrt/mem/heap.h
+++ b/src/libponyrt/mem/heap.h
@@ -12,10 +12,16 @@ PONY_EXTERN_C_BEGIN
 #define HEAP_MINBITS 5
 #define HEAP_MAXBITS (POOL_ALIGN_BITS - 1)
 #define HEAP_SIZECLASSES (HEAP_MAXBITS - HEAP_MINBITS + 1)
-// HEAP_MIN is the minimum (and guaranteed) alignment of every heap allocation.
-// codegen declares it to LLVM as the allocators' `align` return attribute
-// (init_runtime in codegen.c); lowering it below a target's maximum field
-// alignment would silently under-align object fields. See issue #5462.
+// HEAP_MIN is the minimum (and guaranteed) alignment and size of every heap
+// allocation. codegen reads it in two places:
+//   1. as the allocators' `align` return attribute (init_runtime in
+//      codegen.c); lowering it below a target's maximum field alignment would
+//      silently under-align object fields. See issue #5462.
+//   2. in `pointer_min_alloc` (genprim.c), which lowers `Pointer._min_alloc()`
+//      to `max(1, HEAP_MIN / element_size)` — the floor String/Array use when
+//      allocating (constructors, reserve, compact) so they never record a
+//      capacity smaller than the block the allocator actually returns. Changing
+//      HEAP_MIN changes that floor.
 #define HEAP_MIN (1 << HEAP_MINBITS)
 #define HEAP_MAX (1 << HEAP_MAXBITS)
 

--- a/tools/lib/ponylang/pony_compiler/tests/main.pony
+++ b/tools/lib/ponylang/pony_compiler/tests/main.pony
@@ -229,7 +229,7 @@ class \nodoc\ _DefinitionTest is UnitTest
     (Position.create(7, 20), [Position.create(4, 1)], TokenIds.tk_class()) // nominal reference to type in a different file
     (Position.create(8, 5), [Position.create(5, 3)], TokenIds.tk_fvar())
     (Position.create(10, 16), [Position.create(54, 3)], TokenIds.tk_new()) // reference to constructor in a different file
-    (Position.create(10, 30), [Position.create(921, 3)], TokenIds.tk_fun()) // reference to function in a different file
+    (Position.create(10, 30), [Position.create(926, 3)], TokenIds.tk_fun()) // reference to function in a different file
     (Position.create(12, 6), [Position.create(7, 14)], TokenIds.tk_param())
     (Position.create(12, 10), [Position.create(19, 3)], TokenIds.tk_flet()) // reference to behavior in a different file
     (Position.create(12, 15), [Position.create(20, 3)], TokenIds.tk_be()) // reference to behavior in a different file

--- a/tools/lib/ponylang/pony_compiler/tests/main.pony
+++ b/tools/lib/ponylang/pony_compiler/tests/main.pony
@@ -229,7 +229,7 @@ class \nodoc\ _DefinitionTest is UnitTest
     (Position.create(7, 20), [Position.create(4, 1)], TokenIds.tk_class()) // nominal reference to type in a different file
     (Position.create(8, 5), [Position.create(5, 3)], TokenIds.tk_fvar())
     (Position.create(10, 16), [Position.create(54, 3)], TokenIds.tk_new()) // reference to constructor in a different file
-    (Position.create(10, 30), [Position.create(926, 3)], TokenIds.tk_fun()) // reference to function in a different file
+    (Position.create(10, 30), [Position.create(927, 3)], TokenIds.tk_fun()) // reference to function in a different file
     (Position.create(12, 6), [Position.create(7, 14)], TokenIds.tk_param())
     (Position.create(12, 10), [Position.create(19, 3)], TokenIds.tk_flet()) // reference to behavior in a different file
     (Position.create(12, 15), [Position.create(20, 3)], TokenIds.tk_be()) // reference to behavior in a different file


### PR DESCRIPTION
…(#5518)

String and Array rounded capacity to the next power of two, which records a capacity smaller than the runtime allocator's minimum block (HEAP_MIN, 32 bytes) for small collections. Because the heap realloc has no same-size-class fast path, a small collection growing through its first few elements reallocated and copied several times even though it never left the single block the allocator handed out. Building a small string by copying a few characters and then appending hit the same problem.

Add a Pointer[A]._min_alloc() compiler intrinsic and floor capacity with it in the constructors, reserve, and compact of both String and Array. The copying String constructors copy only the content, not the floored capacity, so they do not over-read their source. Format.apply and File.read_string relied on String(len).space() == len, which the floor breaks; both now use the intended length. The HEAP_MIN to codegen dependency is documented at its definition and in the Known Couplings list.