### PR TITLE
Fix constant object comparison

### DIFF
--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -276,15 +276,24 @@ bool is_literal_equal(ast_t* a, ast_t* b, pass_opt_t* opt, bool allow_eq_list)
           ast_t* type_a = ast_type(a);
           ast_t* type_b = ast_type(b);
 
-          ast_t* data_a = (ast_t*)ast_data(type_a);
-          ast_t* data_b = (ast_t*)ast_data(type_b);
-
-          uint64_t a_hash = ast_hash(data_a);
-          uint64_t b_hash = ast_hash(data_b);
-
-          if(a_hash == b_hash)
+          if(ast_id(type_a) == TK_NOMINAL && ast_id(type_b) == TK_NOMINAL)
           {
-            return true;
+            ast_t* data_a = (ast_t*)ast_data(type_a);
+            ast_t* data_b = (ast_t*)ast_data(type_b);
+
+            ast_t* id_a = ast_child(data_a);
+            ast_t* id_b = ast_child(data_b);
+
+            if(ast_data(id_a) != NULL && ast_data(id_b))
+            {
+              uint64_t a_hash = ast_hash(data_a);
+              uint64_t b_hash = ast_hash(data_b);
+
+              if(a_hash == b_hash)
+              {
+                return true;
+              }
+            }
           }
         }
       }

--- a/test/full-program-tests/ctfe/main.pony
+++ b/test/full-program-tests/ctfe/main.pony
@@ -62,6 +62,24 @@ class BareLambdaClass[l: @{(I32): I32} val]
   fun run_lambda(x: I32): I32 =>
     l(x)
 
+class ConstantArrayClass[a: Array[I32] val]
+  fun compare(x: Array[I32]): Bool =>
+    var i: USize = 0
+
+    for e in a.values() do
+      try
+        if e != x(i)? then
+          return false
+        end
+      else
+        return false
+      end
+
+      i = i + 1
+    end
+
+    true
+
 actor Main
   var _env: Env
 
@@ -1131,4 +1149,9 @@ actor Main
 
     if res != 88 then
       @pony_exitcode(exit_add + 3)
+    end
+
+    let cac: ConstantArrayClass[= recover val [1; 2; 3; 4] end] = ConstantArrayClass[= recover val [1; 2; 3; 4] end]
+    if not cac.compare([1; 2; 3; 4]) then
+      @pony_exitcode(exit_add + 4)
     end


### PR DESCRIPTION
Fixed constant object comparison so that a failed comparison only continues if the id of the underlying type has a nice_id (ast_data) provided which indicates a lambda. Otherwise it should be skipped and the objects are truly unequal.

Added CTFE test for constant array as type argument.